### PR TITLE
Fixes doctests to pass on python3.4

### DIFF
--- a/src/manuel/README.txt
+++ b/src/manuel/README.txt
@@ -81,9 +81,9 @@ Also, instead of just a "start_match" attribute, the region will have
 start_match and end_match attributes.
 
     >>> region.start_match
-    <_sre.SRE_Match object at 0x...>
+    <..._sre.SRE_Match object...>
     >>> region.end_match
-    <_sre.SRE_Match object at 0x...>
+    <..._sre.SRE_Match object...>
 
 
 Regions must always consist of whole lines.


### PR DESCRIPTION
We are in process of rebuilding packages with the new release of Python 3.4 in Fedora.

Manuel fails on doctests, see:

```
/builddir/build/BUILD/python3-python-manuel-1.7.2-5.fc21/src/manuel/capture.txt:Error reporting
/builddir/build/BUILD/python3-python-manuel-1.7.2-5.fc21/src/manuel/capture.txt:Error reporting ... ok
turtle_on_the_bottom_test (manuel.tests)
Doctest: manuel.tests.turtle_on_the_bottom_test ... ok
======================================================================
FAIL: /builddir/build/BUILD/python3-python-manuel-1.7.2-5.fc21/src/manuel/README.txt:Parsing
/builddir/build/BUILD/python3-python-manuel-1.7.2-5.fc21/src/manuel/README.txt:Parsing
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/python3-python-manuel-1.7.2-5.fc21/src/manuel/testing.py", line 44, in runTest
    '\n' + DIVIDER + DIVIDER.join(results))
AssertionError: 
----------------------------------------------------------------------
File "/builddir/build/BUILD/python3-python-manuel-1.7.2-5.fc21/src/manuel/README.txt", line 83, in README.txt
Failed example:
    region.start_match
Expected:
    <_sre.SRE_Match object at 0x...>
Got:
    <_sre.SRE_Match object; span=(44, 56), match='one: 1, 2, 3'>
----------------------------------------------------------------------
File "/builddir/build/BUILD/python3-python-manuel-1.7.2-5.fc21/src/manuel/README.txt", line 85, in README.txt
Failed example:
    region.end_match
Expected:
    <_sre.SRE_Match object at 0x...>
Got:
    <_sre.SRE_Match object; span=(70, 84), match='three: 3, 5, 1'>
----------------------------------------------------------------------
Ran 59 tests in 0.166s
FAILED (failures=1)
```

It looks like module `re` changed it's string representation.
