### PR TITLE
Update doctests to support python3.7

### DIFF
--- a/src/manuel/README.txt
+++ b/src/manuel/README.txt
@@ -81,9 +81,9 @@ Also, instead of just a "start_match" attribute, the region will have
 start_match and end_match attributes.
 
     >>> region.start_match
-    <_sre.SRE_Match object...>
+    <...Match object...>
     >>> region.end_match
-    <_sre.SRE_Match object...>
+    <...Match object...>
 
 
 Regions must always consist of whole lines.


### PR DESCRIPTION
`_sre.SRE_Match` is now `re.Match`. To support both py3.7 and older versions, just check for `...Match`.