### PR TITLE
Adapt to python 3.11 change

### DIFF
--- a/src/manuel/index.txt
+++ b/src/manuel/index.txt
@@ -779,7 +779,7 @@ We can see that when executed, the SyntaxError escapes.
       File "<memory>:4", line 2
          def foo:
                 ^
-    SyntaxError: invalid syntax...
+    SyntaxError: ...
 
 The :mod:`manuel.ignore` module provides a way to ignore parts of a document
 using a directive ".. ignore-next-block".


### PR DESCRIPTION
The Fedora Linux distribution is building packages with the current alpha release of python 3.11 to diagnose and fix problems as early as possible.  The manuel package currently fails to pass its tests due to a change in output.  The `SyntaxError` in this commit now looks like this: `SyntaxError: expected '('`.  With this change, the tests pass with python 3.11 alpha 5.