### PR TITLE
Replace TextTestResult with TestResult for Py3.11

### DIFF
--- a/src/manuel/index.txt
+++ b/src/manuel/index.txt
@@ -211,10 +211,7 @@ When tests are run this way:
 
     >>> sys.stdout.writeln = lambda s: sys.stdout.write(s+'\n')
     >>> suite = loader.loadTestsFromTestCase(MyTest)
-    >>> result = suite.run(unittest.TextTestResult(sys.stdout, True, 3))
-    test1 (tests.MyTest) ... ok
-    test2 (tests.MyTest) ... ok
-    test3 (tests.MyTest) ... FAIL
+    >>> result = suite.run(unittest.TestResult(True, 3))
 
     >>> for _, e in result.errors:
     ...     print(e); print


### PR DESCRIPTION
Long story short, unittest >= py3.11 returns `test1 (tests.MyTest.test1) ... ok` instead of `test1 (tests.MyTest) ... ok`

This PR replaces `unittest.TextTestResult` with `unittest.TestResult` which, while not reporting to stdout, still passes the existing metadata check (i.e. expected passes match  and expected failures match) and serves to illustrate usage of `unittest` with manuel.

I had a bit of a fiddle with this one but couldn't find a way to do a conditional, theoretically something similar to the below would preserve existing behaviour.

```python
if sys.version_info() >= (3,11):
    test1 (tests.MyTest.test1) ... ok
    test2 (tests.MyTest.test2) ... ok
    test3 (tests.MyTest.test3) ... FAIL
else:
    test1 (tests.MyTest) ... ok
    test2 (tests.MyTest) ... ok
    test3 (tests.MyTest) ... FAIL
```

If there is a syntax for this that I've missed, please let me know!

Fixes: #30 