### PR TITLE
remove references to old "six" module

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -37,7 +37,6 @@ requests==2.28.0
 requests-toolbelt==0.9.1
 rfc3986==2.0.0
 rich==12.4.4
-six==1.16.0
 snowballstemmer==2.2.0
 tomli==2.0.1
 twine==4.0.1

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
     test_suite='manuel.tests.test_suite',
     install_requires=[
         'setuptools',
-        'six',
         ],
     include_package_data=True,
     long_description=long_description,

--- a/src/manuel/README.txt
+++ b/src/manuel/README.txt
@@ -72,7 +72,7 @@ the begining of a region and the second to identify the end.
     ...     )[0]
     >>> region.lineno
     2
-    >>> six.print_(region.source)
+    >>> print(region.source)
     one: 1, 2, 3
     two: 4, 5, 7
     three: 3, 5, 1
@@ -250,7 +250,7 @@ simplify things.
     ...     42
     ... """)
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted(), end='')
+    >>> print(document.formatted(), end='')
     File "<memory>", line 4, in <memory>
     Failed example:
         1 + 1
@@ -287,7 +287,7 @@ example start string from ">>>" to "py>":
     ...     42
     ... """)
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted(), end='')
+    >>> print(document.formatted(), end='')
     File "<memory>", line 4, in <memory>
     Failed example:
         1 + 1
@@ -319,7 +319,7 @@ to support shell commands and Python code in the same document.
     ...
     ... """)
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted(), end='')
+    >>> print(document.formatted(), end='')
 
 Globals
 -------
@@ -338,7 +338,7 @@ changes made by earlier evaluaters are available to the current evaluator.
     ...     1
     ... """)
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted(), end='')
+    >>> print(document.formatted(), end='')
 
 Imported modules are added to the global namespace as well.
 
@@ -352,7 +352,7 @@ Imported modules are added to the global namespace as well.
     ...
     ... """)
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted(), end='')
+    >>> print(document.formatted(), end='')
 
 
 Combining Test Types
@@ -404,8 +404,8 @@ We can look at the formatted output to see that each of the two tests failed.
 
     >>> for region in document:
     ...     if region.formatted:
-    ...         six.print_('-'*70)
-    ...         six.print_(region.formatted, end='')
+    ...         print('-'*70)
+    ...         print(region.formatted, end='')
     ----------------------------------------------------------------------
     the numbers aren't in sorted order: 3, 6, 2
     ----------------------------------------------------------------------
@@ -438,7 +438,7 @@ and the "insert_region_before" and "insert_region_after" methods of Documents.
     ...         if region.parsed:
     ...             continue
     ...         if region.source.strip().endswith('my clone:'):
-    ...             to_be_cloned = six.advance_iterator(document_iter).copy()
+    ...             to_be_cloned = next(document_iter).copy()
     ...             break
     ...     # if we found the region to cloned, do so
     ...     if to_be_cloned:
@@ -529,7 +529,7 @@ When we run the document through our Manuel instance, we see the additional
 information.
 
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted(), end='')
+    >>> print(document.formatted(), end='')
     File "<memory>", line 10, in <memory>
     Failed example:
         a + b
@@ -560,7 +560,7 @@ in the source (in a comment for example), it will be included in the output:
     ... """)
 
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted(), end='')
+    >>> print(document.formatted(), end='')
     File "<memory>", line 10, in <memory>
     Failed example:
         a + b # doesn't mention "c"
@@ -576,7 +576,7 @@ in the source (in a comment for example), it will be included in the output:
 Instead of a text-based apprach, let's use the built-in tokenize module to more
 robustly identify referenced variables.
 
-    >>> from six import StringIO
+    >>> from io import StringIO
     >>> import token
     >>> import tokenize
 
@@ -608,7 +608,7 @@ included in the debugging information.
 
     >>> document = manuel.Document(document.source)
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted(), end='')
+    >>> print(document.formatted(), end='')
     File "<memory>", line 10, in <memory>
     Failed example:
         a + b # doesn't mention "c"

--- a/src/manuel/bugs.txt
+++ b/src/manuel/bugs.txt
@@ -104,7 +104,7 @@ afterward.
 
 The doctest in the `source` variable ran with no errors.
 
-    >>> six.print_(document.formatted())
+    >>> print(document.formatted())
 
 And now the globs dictionary reflects the changes made when the doctest ran.
 
@@ -163,7 +163,7 @@ Now if we run this test through Manuel, the fake module machinery works.
 
 The doctest in the `source` variable ran with no errors.
 
-    >>> six.print_(document.formatted())
+    >>> print(document.formatted())
 
 We should clean up now.
 
@@ -214,7 +214,7 @@ instead:
 
     >>> from manuel.testing import TestCase
     >>> m = manuel.Manuel()
-    >>> six.print_(TestCase(m, manuel.RegionContainer(), None).id())
+    >>> print(TestCase(m, manuel.RegionContainer(), None).id())
     <memory>
 
 

--- a/src/manuel/doctest.py
+++ b/src/manuel/doctest.py
@@ -1,15 +1,13 @@
-from __future__ import absolute_import
-
 import doctest
 import manuel
 import os.path
-import six
+from io import StringIO
 
 DocTestRunner = doctest.DocTestRunner
 DebugRunner = doctest.DebugRunner
 
 
-class DocTestResult(six.StringIO):
+class DocTestResult(StringIO):
     pass
 
 

--- a/src/manuel/index.txt
+++ b/src/manuel/index.txt
@@ -1076,9 +1076,8 @@ identify them with a marker::
     >>> m = manuel.testcase.MarkerManuel()
     >>> m += manuel.doctest.Manuel()
     >>> document.parse_with(m)
-    >>> import six
     >>> for regions in manuel.testing.group_regions_by_test_case(document):
-    ...     six.print_(regions.location, regions.id)
+    ...     print(regions.location, regions.id)
     <memory> None
     <memory> first-named-test-case
     <memory> second-named-test-case
@@ -1127,9 +1126,8 @@ of test case identification:
 .. make sure above finds all the test cases appropriately
 
     >>> document.parse_with(m)
-    >>> import six
     >>> for regions in manuel.testing.group_regions_by_test_case(document):
-    ...     six.print_(regions.location, regions.id)
+    ...     print(regions.location, regions.id)
     <memory> None
     <memory> First Section
     <memory> first-named-test-case

--- a/src/manuel/table-example.txt
+++ b/src/manuel/table-example.txt
@@ -104,7 +104,6 @@ pertinent details, and instantiate Table objects.
 .. code-block:: python
 
     import re
-    import six
 
     table_start = re.compile(r'(?<=\n\n)=[= ]+\n(?=[ \t]*?\S)', re.DOTALL)
     table_end = re.compile(r'\n=[= ]+\n(?=\Z|\n)', re.DOTALL)
@@ -112,17 +111,17 @@ pertinent details, and instantiate Table objects.
     def parse_tables(document):
         for region in document.find_regions(table_start, table_end):
             lines = enumerate(iter(region.source.splitlines()))
-            six.advance_iterator(lines) # skip the first line
+            next(lines) # skip the first line
 
             # grab the expression to be evaluated
-            expression = six.advance_iterator(lines)[1]
+            expression = next(lines)[1]
             if expression.startswith('\\'):
                 expression = expression[1:]
 
-            six.advance_iterator(lines) # skip the divider line
-            variables = [v.strip() for v in six.advance_iterator(lines)[1].split()][:-1]
+            next(lines) # skip the divider line
+            variables = [v.strip() for v in next(lines)[1].split()][:-1]
 
-            six.advance_iterator(lines) # skip the divider line
+            next(lines) # skip the divider line
 
             examples = []
             for lineno_offset, line in lines:
@@ -143,8 +142,7 @@ If we parse the Document we can see that the table was recognized.
 
     >>> parse_tables(document)
     >>> region = list(document)[1]
-    >>> import six
-    >>> six.print_(region.source, end='')
+    >>> print(region.source, end='')
     =====  =====  ======
     \      A or B
     --------------------
@@ -280,7 +278,7 @@ display the results in a readable fashion.
 We can see how the results are formatted.
 
     >>> format_table_errors(document)
-    >>> six.print_(region.formatted, end='')
+    >>> print(region.formatted, end='')
     when evaluating table at fake.txt, line 6
         fake.txt, line 11: expected True, got False instead.
         fake.txt, line 13: expected False, got True instead.
@@ -305,7 +303,7 @@ Now we can create a fresh document and tell it to do all the above steps
     >>> m = Manuel()
     >>> document = manuel.Document(source_with_errors, location='fake.txt')
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted(), end='')
+    >>> print(document.formatted(), end='')
     when evaluating table at fake.txt, line 6
         fake.txt, line 11: expected True, got False instead.
         fake.txt, line 13: expected False, got True instead.
@@ -314,7 +312,7 @@ Of course, if there were no errors, nothing would be reported:
 
     >>> document = manuel.Document(source, location='fake.txt')
     >>> document.process_with(m, globs={})
-    >>> six.print_(document.formatted())
+    >>> print(document.formatted())
 
 If we wanted to use instances of our Manuel object in a test, we would follow
 the directions in :ref:`getting-started`, importing Manuel from the module

--- a/src/manuel/testing.py
+++ b/src/manuel/testing.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import doctest as real_doctest
 import functools
 import inspect

--- a/src/manuel/tests.py
+++ b/src/manuel/tests.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import doctest
 import manuel
 import manuel.capture


### PR DESCRIPTION
six is only needed when Python2 support is needed

Closes: #33